### PR TITLE
feat: add support for item image uploads and storage

### DIFF
--- a/ScavengerHunt.WebApi/Controllers/ItemController.cs
+++ b/ScavengerHunt.WebApi/Controllers/ItemController.cs
@@ -1,8 +1,8 @@
 using ScavengerHunt.WebApi.Persistance.Entities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using ScavengerHunt.WebApi.Dtos;
 using ScavengerHunt.WebApi.Persistance;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace ScavengerHunt.WebApi.Controllers
 {
@@ -21,20 +21,39 @@ namespace ScavengerHunt.WebApi.Controllers
 
         [HttpPost]
         [Route("{huntid:guid}")]
-        public async Task<IActionResult> CreateItem(Guid? huntId, [FromBody] ItemDto itemDto)
+        public async Task<IActionResult> CreateItem(Guid? huntId, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation($"Creating item for hunt: {huntId}");
             if (huntId == null || huntId == Guid.Empty) return NotFound();
             if (!await _context.Hunts.AnyAsync(a => a.HuntId == huntId)) return NotFound();
 
+            // Get the IFormFeature and read the form
+            var formFeature = Request.HttpContext.Features.GetRequiredFeature<IFormFeature>();
+            await formFeature.ReadFormAsync(cancellationToken);
+
+            // Access the uploaded file (example: first file)
+            var name = Request.Form.SingleOrDefault(f => f.Key == "name").Value;
+            if (string.IsNullOrEmpty(name)) return BadRequest("Item name is required");
+
+            var file = Request.Form.Files.SingleOrDefault();
+            if (file == null) return BadRequest("Image of item is required");
+
+            // TODO: extension validation
+            // TODO: file signature validation
+            // TODO: file size limit validation
+
+            using var memoryStream = new MemoryStream();
+            await file.CopyToAsync(memoryStream, cancellationToken);
+
             await _context.Items.AddAsync(new Item
             {
-                Name = itemDto.Name,
-                FkHuntId = huntId
+                Name = name,
+                FkHuntId = huntId,
+                Image = memoryStream.ToArray()
             });
             await _context.SaveChangesAsync();
 
-            return Created(nameof(ItemController), itemDto);
+            return Created(nameof(ItemController), new { name, huntId });
         }
 
         [HttpGet]

--- a/ScavengerHunt.WebApi/Persistance/Entities/Item.cs
+++ b/ScavengerHunt.WebApi/Persistance/Entities/Item.cs
@@ -4,6 +4,7 @@ namespace ScavengerHunt.WebApi.Persistance.Entities
     {
         public Guid ItemId { get; set; }
         public string Name { get; set; } = string.Empty;
+        public byte[]? Image { get; set; }
 
         public Guid? FkHuntId { get; set; }
         public Hunt? Hunt { get; set; }

--- a/ScavengerHunt.WebApi/Persistance/Migrations/20250623230818_ItemsImage.Designer.cs
+++ b/ScavengerHunt.WebApi/Persistance/Migrations/20250623230818_ItemsImage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScavengerHunt.WebApi.Persistance;
 
@@ -11,9 +12,11 @@ using ScavengerHunt.WebApi.Persistance;
 namespace ScavengerHunt.WebApi.Persistance.Migrations
 {
     [DbContext(typeof(HuntDbContext))]
-    partial class HuntDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250623230818_ItemsImage")]
+    partial class ItemsImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ScavengerHunt.WebApi/Persistance/Migrations/20250623230818_ItemsImage.cs
+++ b/ScavengerHunt.WebApi/Persistance/Migrations/20250623230818_ItemsImage.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScavengerHunt.WebApi.Persistance.Migrations
+{
+    /// <inheritdoc />
+    public partial class ItemsImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Image",
+                table: "Items",
+                type: "varbinary(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Image",
+                table: "Items");
+        }
+    }
+}

--- a/scavengerhunt.react/src/pages/HuntsPage.jsx
+++ b/scavengerhunt.react/src/pages/HuntsPage.jsx
@@ -41,7 +41,11 @@ export default function HuntPage() {
 
       // create items for hunt
       for (const item of values.items) {
-        await createItem(hunt.huntId, { name: item.name });
+        const formData = new FormData();
+        formData.append('name', item.name);
+        formData.append('file', item.picture);
+
+        await createItem(hunt.huntId, formData);
       }
 
       alertDispatch({ type: 'success', message: 'Successfully created hunt!', show: true });

--- a/scavengerhunt.react/src/services/itemService.js
+++ b/scavengerhunt.react/src/services/itemService.js
@@ -1,11 +1,8 @@
-export async function createItem(huntid, item) {
+export async function createItem(huntid, formData) {
     try {
         const response = await fetch(`/api/v1/item/${huntid}`, {
             method: 'POST',
-            body: JSON.stringify(item),
-            headers: {
-                'Content-Type': 'application/json'
-            }
+            body: formData
         });
 
         if (!response.ok) throw Error('HTTP response failure for creating item for hunt');


### PR DESCRIPTION
Introduced file upload functionality in `ItemController.cs` to handle item image uploads using `FormData`. Updated the `Item` entity to include an `Image` property for storing image data as a byte array.

Modified the frontend (`HuntsPage.jsx` and `itemService.js`) to use `FormData` for sending item name and image files. Enhanced validation for item name and image presence, with placeholders for future checks.

Updated the database schema to add an `Image` column to the `Items` table, including migration files (`20250623230818_ItemsImage`) and model snapshot updates in `HuntDbContextModelSnapshot.cs`.